### PR TITLE
fix: travis deploy command not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,15 @@ before_script:
 # build情況：master, develop及PR都會build
 if: (branch IN (master, develop)) OR (type = pull_request)
 
+stages:
+  - name: deploy
+    if: branch IN (master, develop)
+
 # 所有的PR都不會進deploy
 deploy:
   provider: heroku
   edge: true # opt in to dpl v2
   app: afternoon-mountain-41135
   on:
-    branch: (develop, master) # 只有develop, master會自動deploy
+    all_branches: true
   run: npx sequelize db:migrate


### PR DESCRIPTION
### 修復travis command not found的狀況
- 暫時不明原因，但在deploy on branchs列出branch lists時會出錯
- 改用stages限制travis進入deploy階段，但將deploy設定為all_branches: true，希望一樣達成只deploy master, develop的期待